### PR TITLE
Shared PluginLoadContext for multiple instances of the same plugin.

### DIFF
--- a/AudioPlugSharp/PluginLoader.cs
+++ b/AudioPlugSharp/PluginLoader.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -8,11 +9,17 @@ namespace AudioPlugSharp
 {
     public static class PluginLoader
     {
+        private static Dictionary<string, AssemblyLoadContext> Contexts = new Dictionary<string, AssemblyLoadContext>();
+
         public static IAudioPlugin LoadPluginFromAssembly(string assemblyName)
         {
             string assemblyPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 
-            PluginLoadContext loadContext = new PluginLoadContext(Path.Combine(assemblyPath, assemblyName) + ".dll");
+            if (!Contexts.TryGetValue(assemblyPath, out var loadContext))
+            {
+                loadContext = new PluginLoadContext(Path.Combine(assemblyPath, assemblyName) + ".dll");
+                Contexts.Add(assemblyPath, loadContext);
+            }
 
             Assembly pluginAssembly = LoadAssembly(assemblyName, loadContext);
 


### PR DESCRIPTION
Looks like this change:  
 
           I have now committed the change to make the load context not be shared across plugin instances.

_Originally posted by @mikeoliphant in https://github.com/mikeoliphant/AudioPlugSharp/issues/2#issuecomment-1003137360_

reintroduced an old bug related to wpf handles resources. This causes plugin to crash when using multiple instances, because of multiple versions of the assembly being loaded by the wpf framework.
https://github.com/dotnet/wpf/issues/1700

This pr should fix this (at least for single plugin), the issue might still happen when using multiple plugins made with AudioPlugSharp, but it's less likely, because it would require them to share some library containing wpf controls.